### PR TITLE
add: allow_none=True for vdc of esu.Port

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,7 +15,7 @@ copyright = '2023, Rustack LLC'
 author = 'Development Team'
 
 # The full version, including alpha/beta/rc tags
-version = '0.1.13'
+version = '0.1.17'
 language = 'ru'
 
 extensions = [

--- a/esu/__init__.py
+++ b/esu/__init__.py
@@ -34,4 +34,4 @@ from .vdc import Vdc
 from .vm import Vm
 from .vm_metadata import VmMetadata
 
-__version__ = '0.1.16'
+__version__ = '0.1.17'

--- a/esu/port.py
+++ b/esu/port.py
@@ -44,7 +44,7 @@ class Port(BaseAPI):
         id = Field()
         ip_address = Field()
         type = Field()
-        vdc = Field("esu.Vdc")
+        vdc = Field("esu.Vdc", allow_none=True)
         fw_templates = FieldList('esu.FirewallTemplate', allow_none=True)
         network = Field('esu.Network')
         connected = Field(ConnectedObject, allow_none=True)


### PR DESCRIPTION
Some service ports do not belong to any vdc so the field "vdc" should be optional