### PR TITLE
fix: change pypi auth method for cicd

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -18,6 +18,6 @@ jobs:
       run: python setup.py sdist bdist_wheel
     - name: Publish package
       env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
       run: twine upload dist/*


### PR DESCRIPTION
Since PyPI no longer allows the use of a username and password, some changes were required in our CI/CD workflow to make it functional again.